### PR TITLE
Develop

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -37,7 +37,8 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          zef install --/test --deps-only --build-depends --test-depends .
+          # zef install --/test --deps-only --build-depends --test-depends .
+          zef install -v https://github.com/Altai-man/perl6-Compress-Bzip2-Raw.git
 
       - name: Run Tests
         run: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,44 @@
+name: Linux
+
+on:
+  push:
+    branches:
+      - '*'
+    tags-ignore:
+      - '*'
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  raku:
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+        raku-version:
+          - 'latest'
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: Raku/setup-raku@v1
+        with:
+          raku-version: ${{ matrix.raku-version }}
+
+      - name: raku -v
+        run: |
+          raku -v
+
+      - name: raku -V
+        run: |
+          raku -V
+
+      - name: Install Dependencies
+        run: |
+          zef install --/test --depends --build-depends --test-depends .
+
+      - name: Run Tests
+        run: |
+          zef test --debug .

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install Dependencies
         run: |
           # zef install --/test --deps-only --build-depends --test-depends .
-          zef install -v https://github.com/Altai-man/perl6-Compress-Bzip2-Raw.git
+          zef install --/test -v https://github.com/Altai-man/perl6-Compress-Bzip2-Raw.git
 
       - name: Run Tests
         run: |
@@ -46,4 +46,4 @@ jobs:
 
       - name: Install
         run: |
-          zef install --debug .
+          zef install --/test --debug .

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -37,8 +37,12 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          zef install --/test --depends --build-depends --test-depends .
+          zef install --/test --deps-only --build-depends --test-depends .
 
       - name: Run Tests
         run: |
           zef test --debug .
+
+      - name: Install
+        run: |
+          zef install --debug .

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -37,7 +37,8 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          zef install --/test --deps-only --build-depends --test-depends .
+          # zef install --/test --deps-only --build-depends --test-depends .
+          zef install -v https://github.com/Altai-man/perl6-Compress-Bzip2-Raw.git
 
       - name: Run Tests
         run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,45 @@
+name: MacOS
+
+on:
+  push:
+    branches:
+      - '*'
+    tags-ignore:
+      - '*'
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  raku:
+    strategy:
+      matrix:
+        os:
+          - macos-latest
+        raku-version:
+          - 'latest'
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: Raku/setup-raku@v1
+        with:
+          raku-version: ${{ matrix.raku-version }}
+
+      - name: raku -v
+        run: |
+          raku -v
+
+      - name: raku -V
+        run: |
+          raku -V
+
+      - name: Install Dependencies
+        run: |
+          zef install --/test --depends --build-depends --test-depends .
+
+      - name: Run Tests
+        run: |
+          zef test --debug .
+

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -37,9 +37,12 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          zef install --/test --depends --build-depends --test-depends .
+          zef install --/test --deps-only --build-depends --test-depends .
 
       - name: Run Tests
         run: |
           zef test --debug .
 
+      - name: Install
+        run: |
+          zef install --debug .

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install Dependencies
         run: |
           # zef install --/test --deps-only --build-depends --test-depends .
-          zef install -v https://github.com/Altai-man/perl6-Compress-Bzip2-Raw.git
+          zef install --/test -v https://github.com/Altai-man/perl6-Compress-Bzip2-Raw.git
 
       - name: Run Tests
         run: |
@@ -46,4 +46,4 @@ jobs:
 
       - name: Install
         run: |
-          zef install --debug .
+          zef install --/test --debug .

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -37,7 +37,8 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          zef install --/test --deps-only --build-depends --test-depends .
+          # zef install --/test --deps-only --build-depends --test-depends .
+          zef install -v https://github.com/Altai-man/perl6-Compress-Bzip2-Raw.git
 
       - name: Run Tests
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install Dependencies
         run: |
           # zef install --/test --deps-only --build-depends --test-depends .
-          zef install -v https://github.com/Altai-man/perl6-Compress-Bzip2-Raw.git
+          zef install --/test -v https://github.com/Altai-man/perl6-Compress-Bzip2-Raw.git
 
       - name: Run Tests
         run: |
@@ -46,4 +46,4 @@ jobs:
 
       - name: Install
         run: |
-          zef install --debug .
+          zef install --/test --debug .

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,44 @@
+name: Windows
+
+on:
+  push:
+    branches:
+      - '*'
+    tags-ignore:
+      - '*'
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  raku:
+    strategy:
+      matrix:
+        os:
+          - windows-latest
+        raku-version:
+          - 'latest'
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: Raku/setup-raku@v1
+        with:
+          raku-version: ${{ matrix.raku-version }}
+
+      - name: raku -v
+        run: |
+          raku -v
+
+      - name: raku -V
+        run: |
+          raku -V
+
+      - name: Install Dependencies
+        run: |
+          zef install --/test --depends --build-depends --test-depends .
+
+      - name: Run Tests
+        run: |
+          zef test --debug .

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -37,8 +37,12 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          zef install --/test --depends --build-depends --test-depends .
+          zef install --/test --deps-only --build-depends --test-depends .
 
       - name: Run Tests
         run: |
           zef test --debug .
+
+      - name: Install
+        run: |
+          zef install --debug .

--- a/META6.json
+++ b/META6.json
@@ -3,7 +3,7 @@
     "name" : "Compress::Bzip2",
     "license" : "Artistic-2.0",
     "tags": ["Compression"],
-    "version" : "0.4.1",
+    "version" : "0.4.2",
     "auth" : "zef:Altai-man",
     "description" : "High-level bindings to libbzip2",
     "depends" : [ "Compress::Bzip2::Raw" ],

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 perl6-Compress-Bzip2
-[![Linux](https://github.com/pmqs/perl6-Compress-Bzip2/actions/workflows/linux.yml/badge.svg)](https://github.com/pmqs/perl6-Compress-Bzip2/actions/workflows/linux.yml) [![MacOS](https://github.com/pmqs/perl6-Compress-Bzip2/actions/workflows/macos.yml/badge.svg)](https://github.com/pmqs/perl6-Compress-Bzip2/actions/workflows/macos.yml) [![Windows](https://github.com/pmqs/perl6-Compress-Bzip2/actions/workflows/windows.yml/badge.svg)](https://github.com/pmqs/perl6-Compress-Bzip2/actions/workflows/windows.yml)
+[![Linux](https://github.com/Altai-man/perl6-Compress-Bzip2/actions/workflows/linux.yml/badge.svg)](https://github.com/Altai-man/perl6-Compress-Bzip2/actions/workflows/linux.yml) [![MacOS](https://github.com/Altai-man/perl6-Compress-Bzip2/actions/workflows/macos.yml/badge.svg)](https://github.com/Altai-man/perl6-Compress-Bzip2/actions/workflows/macos.yml) [![Windows](https://github.com/Altai-man/perl6-Compress-Bzip2/actions/workflows/windows.yml/badge.svg)](https://github.com/Altai-man/perl6-Compress-Bzip2/actions/workflows/windows.yml)
 ====================
 
 Bindings to bzip2 library. Procedural API is as easy as pie: you can compress and decompress your files like this:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-perl6-Compress-Bzip2  [![Build Status](https://travis-ci.org/Altai-man/perl6-Compress-Bzip2.svg?branch=master)](https://travis-ci.org/Altai-man/perl6-Compress-Bzip2)
+perl6-Compress-Bzip2
+[![Linux](https://github.com/pmqs/perl6-Compress-Bzip2/actions/workflows/linux.yml/badge.svg)](https://github.com/pmqs/perl6-Compress-Bzip2/actions/workflows/linux.yml) [![MacOS](https://github.com/pmqs/perl6-Compress-Bzip2/actions/workflows/macos.yml/badge.svg)](https://github.com/pmqs/perl6-Compress-Bzip2/actions/workflows/macos.yml) [![Windows](https://github.com/pmqs/perl6-Compress-Bzip2/actions/workflows/windows.yml/badge.svg)](https://github.com/pmqs/perl6-Compress-Bzip2/actions/workflows/windows.yml)
 ====================
 
 Bindings to bzip2 library. Procedural API is as easy as pie: you can compress and decompress your files like this:

--- a/lib/Compress/Bzip2.pm6
+++ b/lib/Compress/Bzip2.pm6
@@ -57,7 +57,7 @@ our class X::Bzip2 is Exception {
 }
 
 # Procedural interface.
-our sub compress(Str $filename) is export {
+our sub compress(Str() $filename) is export {
     my int32 $bzerror;
     # FD, Blob, Size.
     my @info = name-to-compress-info($filename);
@@ -72,7 +72,7 @@ our sub compress(Str $filename) is export {
     fclose(@info[0]);
 }
 
-our sub decompress(Str $filename) is export {
+our sub decompress(Str() $filename) is export {
     my int32 $bzerror = BZ_OK;
     # FD, opened stream.
     if !$filename.ends-with(".bz2") {

--- a/t/10-basic.t
+++ b/t/10-basic.t
@@ -4,10 +4,10 @@ use Compress::Bzip2;
 plan *;
 
 my $test = roll 100, "a" .. "z";
-my Str $filename-global = "/tmp/test.txt";
-my Str $filename-rel = "./test.txt";
+my IO::Path $filename-global = $*TMPDIR.add: "raku-compress-bzip2-test.txt"; # replace this with a temp file creator
+my IO::Path $filename-rel = $*CWD.add: "test.txt";
 
-lives-ok { spurt $filename-global, $test }, "Glogal file was written.";
+lives-ok { spurt $filename-global, $test }, "Global file was written.";
 lives-ok { spurt $filename-rel, $test }, "Relative file was written.";
 lives-ok { compress($filename-global) }, "Compression was done.";
 lives-ok { compress($filename-rel) }, "Compression was done.";
@@ -27,7 +27,7 @@ is "Some string", $new, "Compression and decompression from buf to buf seems nor
 
 # Stream compression(will work with stdio, sockets, etc.);
 my $cstream = Compress::Bzip2::Stream.new;
-my $filename = "/tmp/streamed.bz2";
+my $filename = $*CWD.add: "/streamed.bz2";
 my $test-string = "Some test string.".encode;
 my $buffer = buf8.new;
 $buffer ~= $cstream.compress($test-string);


### PR DESCRIPTION
**Changes**
* updated the version to 0.4.2
* Add github workflow files for Linux, MacOS & Windows
* Add github badges to README.md
* Fixes to the test harness to allow working on windows
* Update compress/decompress to optionally take an `IO::Path` or a `Str`

One point to note -- in the workflow files I'm getting `Compress-Bzip2-Raw` directly from https://github.com/Altai-man/perl6-Compress-Bzip2-Raw.git because the updates I made to `Compress-Bzip2-Raw` haven't been pushed to `zef` yet. Once you get the time to push to` zef`, the workflow files need to be updated to change the `Install Dependencies` steps to look like this

```yml
      - name: Install Dependencies
        run: |
          zef install --/test --deps-only --build-depends --test-depends .
```